### PR TITLE
Passing options for iScroll and directive fixed.

### DIFF
--- a/src/lib/angular-iscroll.js
+++ b/src/lib/angular-iscroll.js
@@ -178,9 +178,10 @@
 
         function _link(scope, element, attrs) {
             var options = {
-                iScroll: angular.extend({}, scope.iscroll || {},
+                iScroll: angular.extend({}, scope.iscroll.iScroll || {},
                     iScrollService.defaults.iScroll),
-                directive: angular.extend({}, iScrollService.defaults.directive)
+                directive: angular.extend({}, scope.iscroll.directive || {},
+                    iScrollService.defaults.directive)
             };
 
             angular.forEach(options.iScroll,


### PR DESCRIPTION
Currently there is no way of passing directive's options as stated in readme: 

```
<div iscroll="{iScroll: {mouseWheel: true, momentum: true}, directive: {refreshInterval: 500}}">…</div>
```

It takes whole directive's options content as iScroll options, so the way it works is: 

```
<div iscroll="{mouseWheel: true, momentum: true}">…</div>
```

These small changes are to fix this inconsistency. 
