### PR TITLE
Adds bower.json and bower install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,11 @@ Install the [angular-iscroll NPM package](https://www.npmjs.com/package/angular-
 npm install --save angular-iscroll
 ```
 
+Install through Bower
+```bash
+bower install --save angular-iscroll
+```
+
 Or, to check out a development version, start by cloning the repository, by
 ```bash
 git clone git@github.com:mtr/angular-iscroll.git

--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,28 @@
+{
+  "name": "angular-iscroll",
+  "version": "1.3.2",
+  "description": "AngularJS module that enables iScroll 5 functionality, wrapping it in an easy-to-use directive.",
+  "main": "dist/lib/angular-iscroll.js",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/mtr/angular-iscroll.git"
+  },
+  "keywords": [
+    "iscroll",
+    "angular",
+    "directive"
+  ],
+  "author": {
+    "name": "Martin Thorsen Ranang",
+    "email": "mtr@ranang.org"
+  },
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/mtr/angular-iscroll/issues"
+  },
+  "homepage": "https://github.com/mtr/angular-iscroll",
+  "dependencies": {
+    "angular": ">=1.2",
+    "iscroll": "^5.1.3"
+  }
+}


### PR DESCRIPTION
It's already possible to install the repository through bower, but the without a bower.json it doesn't get the dependencies or set the "main" option. This PR should solve that.
