### PR TITLE
Fixing bug where the argument passed to configureDefaults() clobbers the built-in defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,18 @@ The `iscroll` directive gets its default configuration from the `iScrollService`
 ```js
 /* @ngInject */
 function _config(iScrollServiceProvider) {
-    iScrollServiceProvider.configureDefaults(/* Supply your default configuration object here. */);
+    // Supply a default configuration object, eg:
+    iScrollServiceProvider.configureDefaults({
+        iScroll: {
+            // Passed through to the iScroll library
+            scrollbars: true,
+            fadeScrollbars: true
+        },
+        directive: {
+            // Interpreted by the directive
+            refreshInterval: 500
+        }
+    });
 }
 
 angular

--- a/src/lib/angular-iscroll.js
+++ b/src/lib/angular-iscroll.js
@@ -52,38 +52,39 @@
 
     function iScrollServiceProvider() {
         var defaultOptions = {
-                iScroll: {
-                    /**
-                     * The different options for iScroll are explained in
-                     * detail at http://iscrolljs.com/#configuring
-                     **/
-                    momentum: true,
-                    mouseWheel: true
-                },
-                directive: {
-                    /**
-                     * Delay, in ms, before we asynchronously perform an
-                     * iScroll.refresh().  If false, then no async refresh is
-                     * performed.
-                     **/
-                    asyncRefreshDelay: 0,
-                    /**
-                     * Delay, in ms, between each iScroll.refresh().  If false,
-                     * then no periodic refresh is performed.
-                     **/
-                    refreshInterval: false
-                    /**
-                     * Event handler options are added below.
-                     **/
-                }
-            };
+            iScroll: {
+                /**
+                 * The different options for iScroll are explained in
+                 * detail at http://iscrolljs.com/#configuring
+                 **/
+                momentum: true,
+                mouseWheel: true
+            },
+            directive: {
+                /**
+                 * Delay, in ms, before we asynchronously perform an
+                 * iScroll.refresh().  If false, then no async refresh is
+                 * performed.
+                 **/
+                asyncRefreshDelay: 0,
+                /**
+                 * Delay, in ms, between each iScroll.refresh().  If false,
+                 * then no periodic refresh is performed.
+                 **/
+                refreshInterval: false
+                /**
+                 * Event handler options are added below.
+                 **/
+            }
+        };
 
         angular.forEach(iScrollEventHandlerMap, function _default(event, handler) {
             this[handler] = undefined;
         }, defaultOptions.directive);
 
         function _configureDefaults(options) {
-            angular.extend(defaultOptions, options);
+            angular.extend(defaultOptions.iScroll, options.iScroll);
+            angular.extend(defaultOptions.directive, options.directive);
         }
 
         this.configureDefaults = _configureDefaults;


### PR DESCRIPTION
Fixing bug where the argument passed to configureDefaults() clobbers the built-in defaults, which for me seemed to completely break all iScroll areas, and is also probably not the behavior expected by most users.
